### PR TITLE
Implement CSS variable support

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,23 @@ fn main() {
 }
 ```
 
+### CSS Variables
+
+```rust
+use mew::{style, var};
+use mew::values::{Color};
+
+fn main() {
+    let css = style()
+        .set_var("primary", Color::Red)
+        .custom_property("color", var("primary"))
+        .apply();
+
+    println!("{}", css);
+    // Output: --primary: red; color: var(--primary);
+}
+```
+
 ## Available CSS Properties
 
 ### Color Properties

--- a/examples/css_variables.rs
+++ b/examples/css_variables.rs
@@ -1,0 +1,35 @@
+use mew::style;
+use mew::values::{Color, Size, Display, FontWeight};
+use mew::variable::var;
+
+fn main() {
+    // Create CSS variables
+    let primary_color = var("primary-color");
+    let spacing = var("spacing");
+    let display_mode = var("display-mode");
+    let font_weight = var("font-weight");
+
+    // Use CSS variables in style properties
+    // Method 1: Using explicit enum variants
+    let css1 = style()
+        .color(Color::Var(primary_color.clone()))
+        .background_color(Color::Rgba(240, 240, 240, 0.5))
+        .margin(Size::Var(spacing.clone()))
+        .padding(Size::Px(10))
+        .display(Display::Var(display_mode.clone()))
+        .font_weight(FontWeight::Var(font_weight.clone()))
+        .apply();
+
+    // Method 2: Using Into trait
+    let css2 = style()
+        .color(primary_color.clone().into())
+        .background_color(Color::Rgba(240, 240, 240, 0.5))
+        .margin(spacing.clone().into())
+        .padding(Size::Px(10))
+        .display(display_mode.into())
+        .font_weight(font_weight.into())
+        .apply();
+
+    println!("Generated CSS with variables (Method 1): {}", css1);
+    println!("Generated CSS with variables (Method 2): {}", css2);
+}

--- a/examples/directional_borders.rs
+++ b/examples/directional_borders.rs
@@ -1,0 +1,15 @@
+use mew::style;
+use mew::values::{Color, Size, BorderStyle};
+
+fn main() {
+    // Create a style with directional border properties
+    let css = style()
+        .border_top(Size::Px(1), BorderStyle::Solid, Color::Red)
+        .border_right(Size::Px(2), BorderStyle::Dashed, Color::Blue)
+        .border_bottom(Size::Px(3), BorderStyle::Dotted, Color::Green)
+        .border_left(Size::Px(4), BorderStyle::Double, Color::Black)
+        .apply();
+    
+    println!("Generated CSS with directional borders:");
+    println!("{}", css);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@
 pub mod style;
 pub mod values;
 pub mod properties;
+pub mod variable;
 
 // Include integration tests
 #[cfg(test)]
@@ -27,3 +28,4 @@ mod tests;
 
 // Re-export the main API entry point
 pub use style::style;
+pub use variable::{CssVar, var};

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -212,6 +212,26 @@ pub mod border {
         Property::new("border", format!("{} {} {}", width, style, color))
     }
 
+    /// Create a border-top property (shorthand)
+    pub fn border_top(width: Size, style: BorderStyle, color: Color) -> Property {
+        Property::new("border-top", format!("{} {} {}", width, style, color))
+    }
+
+    /// Create a border-right property (shorthand)
+    pub fn border_right(width: Size, style: BorderStyle, color: Color) -> Property {
+        Property::new("border-right", format!("{} {} {}", width, style, color))
+    }
+
+    /// Create a border-bottom property (shorthand)
+    pub fn border_bottom(width: Size, style: BorderStyle, color: Color) -> Property {
+        Property::new("border-bottom", format!("{} {} {}", width, style, color))
+    }
+
+    /// Create a border-left property (shorthand)
+    pub fn border_left(width: Size, style: BorderStyle, color: Color) -> Property {
+        Property::new("border-left", format!("{} {} {}", width, style, color))
+    }
+
     /// Create a box-shadow property
     pub fn box_shadow(value: BoxShadow) -> Property {
         Property::new("box-shadow", value)

--- a/src/style.rs
+++ b/src/style.rs
@@ -222,6 +222,26 @@ impl Style {
         self.add_property(border::border(width, style, color))
     }
 
+    /// Set the border-top property (shorthand)
+    pub fn border_top(&mut self, width: Size, style: BorderStyle, color: Color) -> &mut Self {
+        self.add_property(border::border_top(width, style, color))
+    }
+
+    /// Set the border-right property (shorthand)
+    pub fn border_right(&mut self, width: Size, style: BorderStyle, color: Color) -> &mut Self {
+        self.add_property(border::border_right(width, style, color))
+    }
+
+    /// Set the border-bottom property (shorthand)
+    pub fn border_bottom(&mut self, width: Size, style: BorderStyle, color: Color) -> &mut Self {
+        self.add_property(border::border_bottom(width, style, color))
+    }
+
+    /// Set the border-left property (shorthand)
+    pub fn border_left(&mut self, width: Size, style: BorderStyle, color: Color) -> &mut Self {
+        self.add_property(border::border_left(width, style, color))
+    }
+
     /// Set the box-shadow property
     pub fn box_shadow(&mut self, value: BoxShadow) -> &mut Self {
         self.add_property(border::box_shadow(value))

--- a/src/style.rs
+++ b/src/style.rs
@@ -36,6 +36,22 @@ impl Style {
         self.apply()
     }
 
+    /// Add a custom property. This allows using raw property names and values
+    /// such as CSS variables.
+    pub fn custom_property<T: fmt::Display>(&mut self, name: &str, value: T) -> &mut Self {
+        self.add_property(Property::new(name, value))
+    }
+
+    /// Define a CSS variable (custom property).
+    pub fn set_var<T: fmt::Display>(&mut self, name: &str, value: T) -> &mut Self {
+        let var_name = if name.trim().starts_with("--") {
+            name.trim().to_string()
+        } else {
+            format!("--{}", name.trim())
+        };
+        self.custom_property(&var_name, value)
+    }
+
     // Color properties
 
     /// Set the color property

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -189,6 +189,10 @@ mod tests {
 
             // 16. border
             .border(Size::Px(1), BorderStyle::Solid, Color::Hex("000".to_string()))
+            .border_top(Size::Px(2), BorderStyle::Solid, Color::Red)
+            .border_right(Size::Px(3), BorderStyle::Dashed, Color::Blue)
+            .border_bottom(Size::Px(4), BorderStyle::Dotted, Color::Green)
+            .border_left(Size::Px(5), BorderStyle::Double, Color::Black)
             .border_style(BorderStyle::None)
             .border_style(BorderStyle::Dashed)
             .border_style(BorderStyle::Double)
@@ -372,6 +376,10 @@ mod tests {
 
         // 16. border
         assert!(css.contains("border: 1px solid #000;"));
+        assert!(css.contains("border-top: 2px solid red;"));
+        assert!(css.contains("border-right: 3px dashed blue;"));
+        assert!(css.contains("border-bottom: 4px dotted green;"));
+        assert!(css.contains("border-left: 5px double black;"));
         assert!(css.contains("border-style: none;"));
         assert!(css.contains("border-style: dashed;"));
         assert!(css.contains("border-style: double;"));

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3,6 +3,7 @@
 #[cfg(test)]
 mod tests {
     use crate::style;
+    use crate::variable::var;
     use crate::values::{
         AlignItems, BorderStyle, BoxShadow, Color, Cursor, Display, FlexDirection, FontSize,
         FontWeight, JustifyContent, LineHeight, Overflow, Position, Size, TextAlign, TextDecoration,
@@ -455,5 +456,16 @@ mod tests {
         assert!(css.contains("visibility: visible;"));
         assert!(css.contains("visibility: hidden;"));
         assert!(css.contains("visibility: collapse;"));
+    }
+
+    #[test]
+    fn test_css_variables() {
+        let css = style()
+            .set_var("primary", Color::Blue)
+            .custom_property("color", var("primary"))
+            .apply();
+
+        assert!(css.contains("--primary: blue;"));
+        assert!(css.contains("color: var(--primary);"));
     }
 }

--- a/src/values.rs
+++ b/src/values.rs
@@ -180,6 +180,9 @@ pub enum Color {
 
     /// Inherit color
     Inherit,
+
+    /// CSS variable
+    Var(crate::variable::CssVar),
 }
 
 impl fmt::Display for Color {
@@ -344,6 +347,7 @@ impl fmt::Display for Color {
             Color::Hsla(h, s, l, a) => write!(f, "hsla({}, {}%, {}%, {})", h, s, l, a),
             Color::CurrentColor => write!(f, "currentColor"),
             Color::Inherit => write!(f, "inherit"),
+            Color::Var(var) => write!(f, "{}", var),
         }
     }
 }
@@ -353,7 +357,7 @@ impl fmt::Display for Color {
 pub enum Size {
     /// Constants
     Zero,
-    
+
     /// Pixel values
     Px(u32),
     /// Percentage values
@@ -368,6 +372,8 @@ pub enum Size {
     Vh(f32),
     /// Auto value
     Auto,
+    /// CSS variable
+    Var(crate::variable::CssVar),
 }
 
 impl fmt::Display for Size {
@@ -381,6 +387,7 @@ impl fmt::Display for Size {
             Size::Vw(val) => write!(f, "{}vw", val),
             Size::Vh(val) => write!(f, "{}vh", val),
             Size::Auto => write!(f, "auto"),
+            Size::Var(var) => write!(f, "{}", var),
         }
     }
 }
@@ -395,6 +402,8 @@ pub enum Display {
     Flex,
     Grid,
     Table,
+    /// CSS variable
+    Var(crate::variable::CssVar),
 }
 
 impl fmt::Display for Display {
@@ -407,6 +416,7 @@ impl fmt::Display for Display {
             Display::Flex => write!(f, "flex"),
             Display::Grid => write!(f, "grid"),
             Display::Table => write!(f, "table"),
+            Display::Var(var) => write!(f, "{}", var),
         }
     }
 }
@@ -419,6 +429,8 @@ pub enum Position {
     Absolute,
     Fixed,
     Sticky,
+    /// CSS variable
+    Var(crate::variable::CssVar),
 }
 
 impl fmt::Display for Position {
@@ -429,6 +441,7 @@ impl fmt::Display for Position {
             Position::Absolute => write!(f, "absolute"),
             Position::Fixed => write!(f, "fixed"),
             Position::Sticky => write!(f, "sticky"),
+            Position::Var(var) => write!(f, "{}", var),
         }
     }
 }
@@ -440,6 +453,8 @@ pub enum FlexDirection {
     RowReverse,
     Column,
     ColumnReverse,
+    /// CSS variable
+    Var(crate::variable::CssVar),
 }
 
 impl fmt::Display for FlexDirection {
@@ -449,6 +464,7 @@ impl fmt::Display for FlexDirection {
             FlexDirection::RowReverse => write!(f, "row-reverse"),
             FlexDirection::Column => write!(f, "column"),
             FlexDirection::ColumnReverse => write!(f, "column-reverse"),
+            FlexDirection::Var(var) => write!(f, "{}", var),
         }
     }
 }
@@ -462,6 +478,8 @@ pub enum JustifyContent {
     SpaceBetween,
     SpaceAround,
     SpaceEvenly,
+    /// CSS variable
+    Var(crate::variable::CssVar),
 }
 
 impl fmt::Display for JustifyContent {
@@ -473,6 +491,7 @@ impl fmt::Display for JustifyContent {
             JustifyContent::SpaceBetween => write!(f, "space-between"),
             JustifyContent::SpaceAround => write!(f, "space-around"),
             JustifyContent::SpaceEvenly => write!(f, "space-evenly"),
+            JustifyContent::Var(var) => write!(f, "{}", var),
         }
     }
 }
@@ -485,6 +504,8 @@ pub enum AlignItems {
     Center,
     Baseline,
     Stretch,
+    /// CSS variable
+    Var(crate::variable::CssVar),
 }
 
 impl fmt::Display for AlignItems {
@@ -495,6 +516,7 @@ impl fmt::Display for AlignItems {
             AlignItems::Center => write!(f, "center"),
             AlignItems::Baseline => write!(f, "baseline"),
             AlignItems::Stretch => write!(f, "stretch"),
+            AlignItems::Var(var) => write!(f, "{}", var),
         }
     }
 }
@@ -508,6 +530,8 @@ pub enum FontWeight {
     Lighter,
     /// Numeric weight (100-900)
     Weight(u16),
+    /// CSS variable
+    Var(crate::variable::CssVar),
 }
 
 impl fmt::Display for FontWeight {
@@ -524,7 +548,8 @@ impl fmt::Display for FontWeight {
                 } else {
                     write!(f, "400") // Default to normal if invalid
                 }
-            }
+            },
+            FontWeight::Var(var) => write!(f, "{}", var),
         }
     }
 }
@@ -538,6 +563,8 @@ pub enum TextAlign {
     Justify,
     Start,
     End,
+    /// CSS variable
+    Var(crate::variable::CssVar),
 }
 
 impl fmt::Display for TextAlign {
@@ -549,6 +576,7 @@ impl fmt::Display for TextAlign {
             TextAlign::Justify => write!(f, "justify"),
             TextAlign::Start => write!(f, "start"),
             TextAlign::End => write!(f, "end"),
+            TextAlign::Var(var) => write!(f, "{}", var),
         }
     }
 }
@@ -560,6 +588,8 @@ pub enum TextDecoration {
     Underline,
     Overline,
     LineThrough,
+    /// CSS variable
+    Var(crate::variable::CssVar),
 }
 
 impl fmt::Display for TextDecoration {
@@ -569,6 +599,7 @@ impl fmt::Display for TextDecoration {
             TextDecoration::Underline => write!(f, "underline"),
             TextDecoration::Overline => write!(f, "overline"),
             TextDecoration::LineThrough => write!(f, "line-through"),
+            TextDecoration::Var(var) => write!(f, "{}", var),
         }
     }
 }
@@ -581,6 +612,8 @@ pub enum Overflow {
     Scroll,
     Auto,
     Clip,
+    /// CSS variable
+    Var(crate::variable::CssVar),
 }
 
 impl fmt::Display for Overflow {
@@ -591,6 +624,7 @@ impl fmt::Display for Overflow {
             Overflow::Scroll => write!(f, "scroll"),
             Overflow::Auto => write!(f, "auto"),
             Overflow::Clip => write!(f, "clip"),
+            Overflow::Var(var) => write!(f, "{}", var),
         }
     }
 }
@@ -607,6 +641,8 @@ pub enum Cursor {
     Grab,
     ZoomIn,
     ZoomOut,
+    /// CSS variable
+    Var(crate::variable::CssVar),
 }
 
 impl fmt::Display for Cursor {
@@ -621,6 +657,7 @@ impl fmt::Display for Cursor {
             Cursor::Grab => write!(f, "grab"),
             Cursor::ZoomIn => write!(f, "zoom-in"),
             Cursor::ZoomOut => write!(f, "zoom-out"),
+            Cursor::Var(var) => write!(f, "{}", var),
         }
     }
 }
@@ -631,6 +668,8 @@ pub enum Visibility {
     Visible,
     Hidden,
     Collapse,
+    /// CSS variable
+    Var(crate::variable::CssVar),
 }
 
 impl fmt::Display for Visibility {
@@ -639,6 +678,7 @@ impl fmt::Display for Visibility {
             Visibility::Visible => write!(f, "visible"),
             Visibility::Hidden => write!(f, "hidden"),
             Visibility::Collapse => write!(f, "collapse"),
+            Visibility::Var(var) => write!(f, "{}", var),
         }
     }
 }
@@ -655,6 +695,8 @@ pub enum BorderStyle {
     Ridge,
     Inset,
     Outset,
+    /// CSS variable
+    Var(crate::variable::CssVar),
 }
 
 impl fmt::Display for BorderStyle {
@@ -669,6 +711,7 @@ impl fmt::Display for BorderStyle {
             BorderStyle::Ridge => write!(f, "ridge"),
             BorderStyle::Inset => write!(f, "inset"),
             BorderStyle::Outset => write!(f, "outset"),
+            BorderStyle::Var(var) => write!(f, "{}", var),
         }
     }
 }
@@ -698,6 +741,8 @@ pub enum FontSize {
     XxLarge,
     /// Calculated value
     Calc(String),
+    /// CSS variable
+    Var(crate::variable::CssVar),
 }
 
 impl fmt::Display for FontSize {
@@ -717,6 +762,7 @@ impl fmt::Display for FontSize {
             FontSize::XLarge => write!(f, "x-large"),
             FontSize::XxLarge => write!(f, "xx-large"),
             FontSize::Calc(expr) => write!(f, "calc({})", expr),
+            FontSize::Var(var) => write!(f, "{}", var),
         }
     }
 }
@@ -734,6 +780,8 @@ pub enum LineHeight {
     Percent(f32),
     /// Calculated value
     Calc(String),
+    /// CSS variable
+    Var(crate::variable::CssVar),
 }
 
 impl fmt::Display for LineHeight {
@@ -744,6 +792,7 @@ impl fmt::Display for LineHeight {
             LineHeight::Length(size) => write!(f, "{}", size),
             LineHeight::Percent(val) => write!(f, "{}%", val),
             LineHeight::Calc(expr) => write!(f, "calc({})", expr),
+            LineHeight::Var(var) => write!(f, "{}", var),
         }
     }
 }
@@ -813,6 +862,8 @@ impl fmt::Display for Transition {
 pub enum ZIndex {
     Auto,
     Index(i32),
+    /// CSS variable
+    Var(crate::variable::CssVar),
 }
 
 impl fmt::Display for ZIndex {
@@ -820,6 +871,126 @@ impl fmt::Display for ZIndex {
         match self {
             ZIndex::Auto => write!(f, "auto"),
             ZIndex::Index(val) => write!(f, "{}", val),
+            ZIndex::Var(var) => write!(f, "{}", var),
         }
+    }
+}
+
+// Implement From<CssVar> for Color to allow automatic conversion
+impl From<crate::variable::CssVar> for Color {
+    fn from(var: crate::variable::CssVar) -> Self {
+        Color::Var(var)
+    }
+}
+
+// Implement From<CssVar> for Size to allow automatic conversion
+impl From<crate::variable::CssVar> for Size {
+    fn from(var: crate::variable::CssVar) -> Self {
+        Size::Var(var)
+    }
+}
+
+// Implement From<CssVar> for Display to allow automatic conversion
+impl From<crate::variable::CssVar> for Display {
+    fn from(var: crate::variable::CssVar) -> Self {
+        Display::Var(var)
+    }
+}
+
+// Implement From<CssVar> for Position to allow automatic conversion
+impl From<crate::variable::CssVar> for Position {
+    fn from(var: crate::variable::CssVar) -> Self {
+        Position::Var(var)
+    }
+}
+
+// Implement From<CssVar> for FlexDirection to allow automatic conversion
+impl From<crate::variable::CssVar> for FlexDirection {
+    fn from(var: crate::variable::CssVar) -> Self {
+        FlexDirection::Var(var)
+    }
+}
+
+// Implement From<CssVar> for JustifyContent to allow automatic conversion
+impl From<crate::variable::CssVar> for JustifyContent {
+    fn from(var: crate::variable::CssVar) -> Self {
+        JustifyContent::Var(var)
+    }
+}
+
+// Implement From<CssVar> for AlignItems to allow automatic conversion
+impl From<crate::variable::CssVar> for AlignItems {
+    fn from(var: crate::variable::CssVar) -> Self {
+        AlignItems::Var(var)
+    }
+}
+
+// Implement From<CssVar> for FontWeight to allow automatic conversion
+impl From<crate::variable::CssVar> for FontWeight {
+    fn from(var: crate::variable::CssVar) -> Self {
+        FontWeight::Var(var)
+    }
+}
+
+// Implement From<CssVar> for TextAlign to allow automatic conversion
+impl From<crate::variable::CssVar> for TextAlign {
+    fn from(var: crate::variable::CssVar) -> Self {
+        TextAlign::Var(var)
+    }
+}
+
+// Implement From<CssVar> for TextDecoration to allow automatic conversion
+impl From<crate::variable::CssVar> for TextDecoration {
+    fn from(var: crate::variable::CssVar) -> Self {
+        TextDecoration::Var(var)
+    }
+}
+
+// Implement From<CssVar> for Overflow to allow automatic conversion
+impl From<crate::variable::CssVar> for Overflow {
+    fn from(var: crate::variable::CssVar) -> Self {
+        Overflow::Var(var)
+    }
+}
+
+// Implement From<CssVar> for Cursor to allow automatic conversion
+impl From<crate::variable::CssVar> for Cursor {
+    fn from(var: crate::variable::CssVar) -> Self {
+        Cursor::Var(var)
+    }
+}
+
+// Implement From<CssVar> for Visibility to allow automatic conversion
+impl From<crate::variable::CssVar> for Visibility {
+    fn from(var: crate::variable::CssVar) -> Self {
+        Visibility::Var(var)
+    }
+}
+
+// Implement From<CssVar> for BorderStyle to allow automatic conversion
+impl From<crate::variable::CssVar> for BorderStyle {
+    fn from(var: crate::variable::CssVar) -> Self {
+        BorderStyle::Var(var)
+    }
+}
+
+// Implement From<CssVar> for ZIndex to allow automatic conversion
+impl From<crate::variable::CssVar> for ZIndex {
+    fn from(var: crate::variable::CssVar) -> Self {
+        ZIndex::Var(var)
+    }
+}
+
+// Implement From<CssVar> for FontSize to allow automatic conversion
+impl From<crate::variable::CssVar> for FontSize {
+    fn from(var: crate::variable::CssVar) -> Self {
+        FontSize::Var(var)
+    }
+}
+
+// Implement From<CssVar> for LineHeight to allow automatic conversion
+impl From<crate::variable::CssVar> for LineHeight {
+    fn from(var: crate::variable::CssVar) -> Self {
+        LineHeight::Var(var)
     }
 }

--- a/src/variable.rs
+++ b/src/variable.rs
@@ -1,0 +1,33 @@
+use std::fmt;
+
+/// A CSS custom property reference.
+///
+/// This struct represents a reference to a CSS variable used in property
+/// values. It simply stores the variable name and formats it as
+/// `var(--name)` when displayed.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CssVar(String);
+
+impl CssVar {
+    /// Create a new CSS variable reference.
+    pub fn new(name: &str) -> Self {
+        let trimmed = name.trim();
+        let name = if trimmed.starts_with("--") {
+            trimmed.to_string()
+        } else {
+            format!("--{}", trimmed)
+        };
+        Self(name)
+    }
+}
+
+impl fmt::Display for CssVar {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "var({})", self.0)
+    }
+}
+
+/// Convenience function to create a [`CssVar`].
+pub fn var(name: &str) -> CssVar {
+    CssVar::new(name)
+}


### PR DESCRIPTION
## Summary
- introduce `CssVar` type and helper `var` function
- add `custom_property` and `set_var` methods for setting CSS variables
- document variables usage in README
- test variable features
- rename `css_var` helper to `var`

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6855ec6ea33c8328980dd9f598f3549c